### PR TITLE
changed "footer" class to "footer-note"

### DIFF
--- a/ferrerih_qfg_stylesheet.css
+++ b/ferrerih_qfg_stylesheet.css
@@ -102,7 +102,7 @@ div
 	font-size:100%;
 	color:#333;
 }
-.footer
+.footer-note
 {
 	font-family: "Pixelar Regular W01 Regular", myFirstFont;
 	line-height: 85%;

--- a/quest-for-glory.html
+++ b/quest-for-glory.html
@@ -140,7 +140,7 @@
 				alt="Valid CSS!" />
 				</a>
 			</div>
-			<div class="footer">Last updated on 3/18/2016.</div>
+			<div class="footer-note">Last updated on 3/18/2016.</div>
 		    </footer>
 
 		</div>


### PR DESCRIPTION
I had an element within a footer which was also labeled as a "footer,"
but by class rather than element name. This seemed wrong what with the
semantic HTML5 element having replaced the earlier <div class="footer"> option
so I changed it to "footer-note."