### PR TITLE
fixed figure margin

### DIFF
--- a/stylereflow.css
+++ b/stylereflow.css
@@ -196,12 +196,21 @@ section.center
 	max-width:80%;
 	margin:auto;
 	}
+	figure
+	{
+	margin:0px !important;
+    -webkit-margin-before: 0em !important;
+    -webkit-margin-after: 0em !important;
+    -webkit-margin-start: 0em !important;
+    -webkit-margin-end: 0em !important;
+	}
 @media (max-width: 30em)
 {
 figcaption
 {
 	display: none;
 }
+
 }
 @media (min-width:30em)
 {


### PR DESCRIPTION
The ```<figure>``` element had an unnecessary margin so I made rules
specifying zero margin.