### PR TITLE
initialize vs initmap function in callback

### DIFF
--- a/home-town.html
+++ b/home-town.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" type="text/css" href="690-227-stylesheet.css">
     <style type="text/css">
     </style>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBeA2BQSNITyOING0Rwsfq6-Mcdm0dm_90&callback=initialize"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBeA2BQSNITyOING0Rwsfq6-Mcdm0dm_90&callback=initMap"></script>
     <script>
 		var map;
 		var myloc;


### PR DESCRIPTION
I am changing the callback function from initialize to initMap in
accordance with the instructions from Google Developers and an error
message complaining that initialize is "not a function."