### PR TITLE
font size and padding on path page

### DIFF
--- a/690-227-stylesheet.css
+++ b/690-227-stylesheet.css
@@ -240,7 +240,7 @@ ul
 	height: 18.75em;
 	width: 28.125em;
 }
-section.center
+section.center, div.summary, div.flex
 {
 	font-size: 100%;
 	padding: 1.5em;


### PR DESCRIPTION
For some elements on the path page, I set the font size, width and
padding to the same as those of section.center at some screen widths.