### PR TITLE
jQuery workaround

### DIFF
--- a/quest-for-glory.html
+++ b/quest-for-glory.html
@@ -32,10 +32,15 @@
 		$("#main-title").mouseover(function()
 		{
 			$("#game-toolbar").slideDown("slow");
+		    $(".button").show();
 		});
 		$("#main-title").mouseout(function()
 		{
 			$("#game-toolbar").slideUp("slow");
+		});
+		$(".smaller-note").click(function()
+		{
+		   $(".button").show();
 		});
 	});
 	</script>


### PR DESCRIPTION
For the moment I have edited the JQuery so that mousing over the title
ensures that the menu button is visible. Clicking on a back to top
button should now do the same thing. This gets around the problem of the
menu button, having disappeared at the affix point, not reappearing when
scrolling back to the top of the page.