### PR TITLE
fixed reference to Hero6

### DIFF
--- a/quest-for-glory.html
+++ b/quest-for-glory.html
@@ -113,7 +113,7 @@
 			A "role-playing adventure game" entitled <a href="http://hero-u.com/about/">Hero U</a> is currently under development by Sierra designers Corey and Lori Cole,
 			who were responsible for the <cite>Quest for Glory</cite> series and contributed to various other Sierra games such as <cite>King's Quest V</cite>.
 			Another apparently unfinished effort at a <cite><abbr title="Quest for Glory">QfG</abbr></cite>-inspired game, this one
-			entitled <cite>Hero 6</cite>, can be found <a href="http://www.questformoreglory.com/forums/index.php?showtopic=3365">here</a>.
+			entitled <cite>Hero6</cite>, can be found <a href="http://www.hero6.org/">here</a>.
 			</p>
 			<div class="smaller-note"><a href="#container">Back to top &uarr;</a>
 			</div>


### PR DESCRIPTION
I fixed a reference to Hero6, both to remove the space from "Hero 6" and
to fix the link to a more up-to-date source, namely the game's website
rather than a Quest for More Glory forum.