### PR TITLE
Revert "updated jQuery references"

### DIFF
--- a/marijuana-policy-page-b.html
+++ b/marijuana-policy-page-b.html
@@ -7,9 +7,9 @@
    <meta charset="utf-8">
    <meta name="viewport" content="initial-scale=1.0, width=device-width">
    <meta name="author" content="Brendan Ferreri-Hanberry">
-   <meta name="description" content="Last modified 7/23/2018">  
+   <meta name="description" content="Last modified 5/5/2018">  
    <link rel="stylesheet" href="jquery.mobile-1.4.5.min.css" />
-   <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+   <script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
    <link href="stylereflow.css" rel="stylesheet" /> <!-- place last !!!  -->
 </head>
 <body>
@@ -489,7 +489,7 @@
 			</div>
 		</footer>
 		</section>
-		<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+		<script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
 		<script src="https://code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.js"></script>
 </body>
 </html>

--- a/quest-for-glory.html
+++ b/quest-for-glory.html
@@ -13,7 +13,7 @@
     <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 	<!-- jQuery library -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
 	<!-- Latest compiled JavaScript -->
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 	<!--Bootstrap-->


### PR DESCRIPTION
Reverts bdferr/bdferr.github.io#111
This had created a conflict between the old version of Bootstrap and the newer version of jQuery, and also between the newer version of jQuery and the older version of jQuery mobile.