### PR TITLE
Quest for glory

### DIFF
--- a/ferrerih_qfg_stylesheet.css
+++ b/ferrerih_qfg_stylesheet.css
@@ -1,4 +1,4 @@
-/*last updated 8/31/2018*/
+/*last updated 9/1/2018*/
 
 /*I added this according to W3Schools' recommendation;
 these elements should already be displayed as blocks 
@@ -159,14 +159,7 @@ ul.dropdown-menu a:visited {
 	text-decoration: none; 
 	font-weight: normal; 
 }
-.toolbar-showing {
-	overflow-y: hidden;
-	transition-property: all;
-	transition-duration: 1s;
-}
-.toolbar-hidden {	
-	max-height: 0px !important;
-}
+
 header {
 	text-align: center; 
 	color: #000; 

--- a/ferrerih_qfg_stylesheet.css
+++ b/ferrerih_qfg_stylesheet.css
@@ -469,7 +469,7 @@ button.affix {
 ul.affix {
 	position: fixed; 
 	left: 35%; 
-	top: 70px; 
+	top: 40px; 
 }
 .center {
     font-family: "Pixelar Regular W01 Regular", Sylfaen, "Times New Roman", serif !important; 
@@ -478,9 +478,7 @@ ul.affix {
 	font-size: 3em; 
 }
 #feet-icon {
-	display: block; 
-	max-height: 28px; 
-	max-width: 23px; 
+	display: none;
 }
 footer {
 	font-family: "Pixelar Regular W01 Regular", Sylfaen, "Times New Roman", serif !important; 

--- a/ferrerih_qfg_stylesheet.css
+++ b/ferrerih_qfg_stylesheet.css
@@ -286,7 +286,16 @@ button, .btn, .btn-primary, .btn-primary.active, .btn.active.btn-primary.active.
 	display: block; 
 }*/
 .affix {
-	visibility: hidden; 
+	visibility: visible; 
+}
+button.affix {
+	top: 0%; 
+	left: 20%; 
+}
+ul.affix {
+	position: fixed; 
+	left: 20%; 
+	top: 40px; 
 }
 .container {
 	margin: 0; 
@@ -451,7 +460,16 @@ button, .btn, .btn-primary, .btn-primary.active, .btn.active.btn-primary.active.
 	display: block; 
 }*/
 .affix {
-	visibility: hidden; 
+	visibility: visible; 
+}
+button.affix {
+	top: 0%; 
+	left: 35%; 
+}
+ul.affix {
+	position: fixed; 
+	left: 35%; 
+	top: 70px; 
 }
 .center {
     font-family: "Pixelar Regular W01 Regular", Sylfaen, "Times New Roman", serif !important; 
@@ -615,7 +633,16 @@ button, .btn, .btn-primary, .btn-primary.active, .btn.active.btn-primary.active.
 	display: block; 
 }*/
 .affix {
-	visibility:hidden; 
+	visibility:visible; 
+}
+button.affix {
+	top: 0%; 
+	left: 76%; 
+}
+ul.affix {
+	position: fixed; 
+	left: 76%; 
+	top: 92px; 
 }
 .center {
 	width: 67%; 

--- a/quest-for-glory.html
+++ b/quest-for-glory.html
@@ -96,10 +96,10 @@
 			Others have already implemented some of the <a href="http://www.questformoreglory.com/downloads/qfg-cursorsT.html">cursors</a> 
 			from the game as extensions to an operating system.
 			</p>
-			<div class="smaller-note"><a href="#container">Back to top &uarr;</a>
+			<div id="downloads" class="smaller-note"><a href="#container">Back to top &uarr;</a>
 			</div>
 			</section>
-            <section id="downloads">
+            <section>
 			<h2>Downloads</h2>
 			<p>
 			All five of the original games in the series can be had cheaply 
@@ -140,10 +140,10 @@
 			Demo videos of this mod, known as <cite>Quest for Glory IV 3D</cite>, 
 			can be found <a href="https://www.youtube.com/watch?v=d7HBenoe_Lc">here</a>.
 			</p>
-			<div class="smaller-note"><a href="#container">Back to top &uarr;</a>
+			<div id="images" class="smaller-note"><a href="#container">Back to top &uarr;</a>
 			</div>
 			</section>
-			<section id="images">
+			<section>
 		    <h2>Game Images</h2>
 			<p>Here are some gameplay images, to give a sense of what this page is attempting to emulate.
 			<a href="http://www.spriters-resource.com/pc_computer/questforglory4/sheet/53053/">Here</a> are some background images. 
@@ -207,9 +207,9 @@
 				<span class="sr-only">Next</span>
 			    </a>
 			</div>
-			<div class="smaller-note"><a href="#container">Back to top &uarr;</a></div>
+			<div id="icons" class="smaller-note"><a href="#container">Back to top &uarr;</a></div>
 			</section>
-			<section id="icons">
+			<section>
 			<h3>Icons</h3>
 			<p>Here are some icons from the game, plus a bullet image used in some of the menus in the game.
 			The icons are used to interact with the environment in different ways; 
@@ -224,8 +224,8 @@
 			<img src="QfG_icons/eye-icon-center.png" id="eye-icon" alt="eye icon">
 			<img src="QfG_icons/mouth-icon4.png" id="mouth-icon" alt="mouth icon">
 			<img src="QfG_icons/li-red-bullet-smaller.png" id="red-bullet" alt="red bullet">
-			<div class="smaller-note"><a href="#container">Back to top &uarr;</a></div>
-			<h2 id="music">Music</h2>
+			<div id="music" class="smaller-note"><a href="#container">Back to top &uarr;</a></div>
+			<h2>Music</h2>
 			<iframe src="https://www.youtube.com/embed/Czh4n_ARKi8"></iframe>
 			<p>
 			The music for this game has been described as "gothic, folk and rock" and includes a rendition


### PR DESCRIPTION
I made the navigation menu visible in the affix position at every media query; previously it had only been visible at wider widths. I made adjustments to accommodate this including moving the navigation anchors for each section to the "back to top notes" immediately above them so that the user could navigate to a section using the menu without the menu button then covering up the section heading.