### PR TITLE
fix CSS rules re: background

### DIFF
--- a/ferrerih_qfg_stylesheet.css
+++ b/ferrerih_qfg_stylesheet.css
@@ -92,6 +92,22 @@ body {
 	cursor: url("QfG_icons/sword-icon2.png"), default !important;
 }
 
+body:before {
+  content: "";
+  display: block;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -10;
+  background: url("cranium-lab-empty.jpg") no-repeat center center;
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
+}
+
 .carousel-indicators {
 	z-index: 9 !important; 
 }
@@ -283,10 +299,6 @@ ul.affix {
 	width: 100%; 
 	height: auto; 
 	font-size: 100%; 
-	background-image: url("cranium-lab-empty.jpg"); 
-	background-position: 40% 0%; 
-	background-repeat: no-repeat; 
-	background-attachment: fixed; 
 }
 
 #feet-icon {
@@ -400,10 +412,6 @@ li.othernavbar {
 }
 
 .container {
-	background-image: url("cranium-lab-empty.jpg"); 
-	background-position: 40% 0%; 
-	background-repeat: no-repeat; 
-	background-attachment: fixed; 
 	padding: 0 0 120px 0; 
 }
 button, .btn {
@@ -587,10 +595,6 @@ ul.affix {
 	font-size: 3em; 
 }
 .container {
-	background-image: url("cranium-lab-empty.jpg"); 
-	background-position: 40% 0%; 
-	background-repeat: no-repeat; 
-	background-attachment: fixed; 
 	padding: 0 0 150px 0; 
 }
 #feet-icon {
@@ -743,10 +747,6 @@ button, .btn {
 	font-size: 3.5em; 
 }
 .container {
-	background-image: url("drcranium.jpg"), url("cranium-lab-empty.jpg"); 
-	background-position: 0% 0%, 40% 0%; 
-	background-repeat: no-repeat; 
-	background-attachment: fixed; 
 	padding: 0 0 215px 0; 
 }
 #feet-icon {
@@ -885,11 +885,11 @@ ul.affix {
 	font-size: 4em; 
 }
 .container {
-	background-image: url("drcranium.jpg"), url("cranium-lab-empty.jpg"); 
-	background-position: 0% 0%, 40% 0%; 
+	padding: 0 0 240px 0;
+	background-image: url("drcranium.jpg"); 
+	background-position: 0% 0%; 
 	background-repeat: no-repeat; 
-	background-attachment: fixed; 
-	padding: 0 0 240px 0; 
+	background-attachment: fixed;
 }
 button, .btn {
 	font-family: "Pixelar Regular W01 Regular", Sylfaen, "Times New Roman", serif; 

--- a/quest-for-glory-de.html
+++ b/quest-for-glory-de.html
@@ -48,7 +48,7 @@
 		<header>
 		<img src="qfg4-toolbar1.jpg" id="game-toolbar" alt="game toolbar" />
 		<h1 id="main-title">Quest for Glory IV</h1>
-			<div id="dropdown_menu" class="dropdown offset" >
+			<div id="dropdown_menu" class="dropdown offset">
 				<button class="btn btn-primary btn-lg dropdown-toggle" type="button" data-toggle="dropdown" data-spy="affix" data-offset-top="231">
 				&nbsp; Wohin? &nbsp;
 					<img id="feet-icon" src="QfG_icons/feet-icon.png" alt="feet icon" />

--- a/quest-for-glory.html
+++ b/quest-for-glory.html
@@ -48,7 +48,7 @@
 		<header>
 		<img src="qfg4-toolbar1.jpg" id="game-toolbar" alt="game toolbar" />
 		<h1 id="main-title">Quest for Glory IV</h1>
-			<div id="dropdown_menu" class="dropdown offset" >
+			<div id="dropdown_menu" class="dropdown offset">
 				<button class="btn btn-primary btn-lg dropdown-toggle" type="button" data-toggle="dropdown" data-spy="affix" data-offset-top="231">
 				Where to?
 					<img id="feet-icon" src="QfG_icons/feet-icon.png" alt="feet icon" />


### PR DESCRIPTION
Change the CSS rules regarding the main background image to fix a scrolling bug. It had been set to "fixed" but had not rendered that way on a mobile device.

Also expand the background to fill the whole width of the screen and set Dr. Cranium to only appear when the screen is wide enough that his head will not be blocked by the title.