### PR TITLE
add margins to icons

### DIFF
--- a/ferrerih_qfg3_stylesheet.css
+++ b/ferrerih_qfg3_stylesheet.css
@@ -10,21 +10,25 @@ header,footer, article, section {
 	height: 26px;
 	width: 53px;
 	display: inline;
+	margin: 5px 0px;
 }
 #hand-icon {
 	height: 48px; 
 	width: 58px;
 	display: inline;
+	margin: 5px 0px;
 }
 #mouth-icon {
 	height: 29px; 
 	width: 64px;
 	display: inline;
+	margin: 5px 0px;
 }
 #sword-icon {
 	height: 81px; 
 	width: 82px; 
 	display: inline;
+	margin: 5px 0px;
 }
 #question-mark-icon {
 	height: 44px;


### PR DESCRIPTION
Add top and bottom margins to QfG3 icons displayed in Icons section; make less crowded.