### PR TITLE
improve text under Icons

### DIFF
--- a/quest-for-glory3.html
+++ b/quest-for-glory3.html
@@ -9,7 +9,7 @@
 	<meta name="description" content="Fanpage for the Sierra role-playing adventure game Quest for Glory III,
 	demonstrating Bootstrap and jQuery. Applies UI elements of game to website."/>
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2021-06-01" />
+	<meta name="dcterms.modified" content="2021-06-05" />
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
 	<!--[if lt IE 9]>
@@ -210,7 +210,8 @@
 			<p>Here are some icons from the game.
 			The icons are used to interact with the environment in different ways; 
 			for example, the mouth icon is used to speak with someone, 
-			while the walking icon	you can see in this page's navigation menu is used to walk somewhere.
+			while the walking man you can see here when you mouse over a link is used to walk somewhere.
+			They appear different depending on whether it is day or night in the game, so they are presented in pairs below.
 			An attempt has already been made by others to implement	some of these as 
 			<a href="http://www.questformoreglory.com/downloads/qfg-cursorsT.html" target="_blank">extensions</a> to an operating system.
 			</p>


### PR DESCRIPTION
Edit text in Icons section to explain that icons look different depending on time of day. Change reference to walking icon in navigation menu because this is only displayed at larger screen widths.