### PR TITLE
fix padding for menu items again

### DIFF
--- a/ferrerih_qfg1_stylesheet.css
+++ b/ferrerih_qfg1_stylesheet.css
@@ -324,12 +324,12 @@ h1 {
 	background-color: transparent; 
 	line-height: 80% !important; 
 	height: 45px;
-	padding: 0em 0.5em 0.45em 0.5em !important; 
+	padding: 0em 0.8em 0.45em 0.8em !important; 
 }
 #li-top {
 	background-image: url("qfg1-li-top.png"); 
 	background-size: contain; 
-	padding: 0.2em 0.5em 0.5em 0.5em !important; 
+	padding: 0.2em 0.8em 0.5em 0.8em !important; 
 	height: 45px; 
 }
 li.othernavbar {
@@ -337,7 +337,7 @@ li.othernavbar {
 	background-size: contain; 
 	font-size: 1.5em; 
 	background-color: transparent;
-	padding: 0em 0.5em; 
+	padding: 0em 0.8em; 
 	margin: 0; 
 	width: 219px;
 	height: 45px;


### PR DESCRIPTION
Fix error in padding adjustments for QfG1 menu items. Again this is to make sure highlighted area on mouseover fits well within menu border regardless of screen width.