### PR TITLE
improve Downloads sections

### DIFF
--- a/quest-for-glory1.html
+++ b/quest-for-glory1.html
@@ -166,10 +166,10 @@
 			<p>
 			Many more downloads including screenshots can be found at a fan page 
 			called <a href="http://www.questformoreglory.com/index3.html" target="_blank">Quest for More Glory</a>,
-			while help for various problems, including the game's rather creative manuals, 
-			is available at <a href="http://www.sierrahelp.com/Games/QuestForGlory/QfG4Help.html" target="_blank">Sierrahelp.com</a>.
+			while help for various problems, including the game's manual, 
+			is available at <a href="http://www.sierrahelp.com/Games/QuestForGlory/QfG1VGAHelp.html" target="_blank">Sierrahelp.com</a>.
 			Sierragamers.com supplies the 
-			<a href="https://web.archive.org/web/20191031132852/https://www.sierragamers.com/uploads/24082/Hint_Book/Quest_for_Glory_4_Hint_Book.pdf" target="_blank">hint book</a>. 
+			<a href="https://www.sierragamers.com/wp-content/uploads/2019/12/Quest_for_Glory_1_Hint_Book.pdf" target="_blank">hint book</a>. 
 			</p>
 			<p>
 			A fan has created a modification to the classic first-person shooter game Hexen in which the player 

--- a/quest-for-glory3.html
+++ b/quest-for-glory3.html
@@ -124,10 +124,10 @@
 			<p>
 			Many more downloads including screenshots can be found at a fan page 
 			called <a href="http://www.questformoreglory.com/index3.html" target="_blank">Quest for More Glory</a>,
-			while help for various problems, including the game's rather creative manuals, 
-			is available at <a href="http://www.sierrahelp.com/Games/QuestForGlory/QfG4Help.html" target="_blank">Sierrahelp.com</a>.
+			while help for various problems, including the game's manual, 
+			is available at <a href="http://www.sierrahelp.com/Games/QuestForGlory/QfG3Help.html" target="_blank">Sierrahelp.com</a>.
 			Sierragamers.com supplies the 
-			<a href="https://web.archive.org/web/20191031132852/https://www.sierragamers.com/uploads/24082/Hint_Book/Quest_for_Glory_4_Hint_Book.pdf" target="_blank">hint book</a>. 
+			<a href="https://www.sierragamers.com/wp-content/uploads/2019/12/Quest_for_Glory_3_Hint_Book.pdf" target="_blank">hint book</a>. 
 			</p>
 			<p>
 			A fan has created a modification to the classic first-person shooter game Hexen in which the player 

--- a/quest-for-glory4.html
+++ b/quest-for-glory4.html
@@ -136,7 +136,7 @@
 			while help for various problems, including the game's rather creative manuals, 
 			is available at <a href="http://www.sierrahelp.com/Games/QuestForGlory/QfG4Help.html" target="_blank">Sierrahelp.com</a>.
 			Sierragamers.com supplies the 
-			<a href="https://web.archive.org/web/20191031132852/https://www.sierragamers.com/uploads/24082/Hint_Book/Quest_for_Glory_4_Hint_Book.pdf" target="_blank">hint book</a>. 
+			<a href="https://www.sierragamers.com/wp-content/uploads/2019/12/Quest_for_Glory_4_Hint_Book.pdf" target="_blank">hint book</a>. 
 			</p>
 			<p>
 			A fan has created a modification to the classic first-person shooter game Hexen in which the player 


### PR DESCRIPTION
Edit the Downloads section text of QfG1 and QfG3 pages to remove text/links specific to QfG4, replace with content specific to QfG1 and QfG3. Replace link to archived version of QfG4 hint book with link to current Sierragamers.com page.