### PR TITLE
add daytime class to elements by default

### DIFF
--- a/quest-for-glory1.html
+++ b/quest-for-glory1.html
@@ -121,12 +121,12 @@
 			</p>
     		<p>
 			My main purpose here is to follow up
-			on an <a href="http://inls718userinterfacedesign.blogspot.com/2015/01/i-miss-days-whenpixels-were-clearly.html" target="_blank">idea</a> 
+			on an <a href="http://inls718userinterfacedesign.blogspot.com/2015/01/i-miss-days-whenpixels-were-clearly.html" class="day" target="_blank">idea</a> 
 			which came to me in 2015 in the context of a user interface course in graduate school.
 			Originally this applied only to <cite>Quest for Glory IV</cite>, but here I am applying it to <cite>Quest for Glory I</cite>.
 			I am taking much of the interface of the game, including the graphics 
 			for the game's text boxes and menus, and applying it to a website.
-			Others have already implemented some of the <a href="http://www.questformoreglory.com/downloads/qfg-cursorsT.html" target="_blank">cursors</a> 
+			Others have already implemented some of the <a href="http://www.questformoreglory.com/downloads/qfg-cursorsT.html" class="day" target="_blank">cursors</a> 
 			from the game as extensions to an operating system.
 			</p>
 			<p>
@@ -134,51 +134,51 @@
 			This was an unusual idea for games of the time and must have made it more engaging. 
 			I am trying to approximate this with the "night mode" option, which you can activate by clicking the text in the footer.
 			</p>
-			<div id="downloads" class="smaller-note"><a href="#container">Back to top &uarr;</a>
+			<div id="downloads" class="smaller-note"><a href="#container" class="day">Back to top &uarr;</a>
 			</div>
 			</section>
             <section>
 			<h2>Downloads</h2>
 			<p>
 			All five of the original games in the series can be had cheaply 
-			from <a href="https://www.gog.com/game/quest_for_glory" target="_blank">GOG.com</a>.
+			from <a href="https://www.gog.com/game/quest_for_glory" class="day" target="_blank">GOG.com</a>.
 			This set of the games includes a remake of the first title with far better graphics, 
 			but unfortunately those of the second game are still rather primitive. You can however download 
-			a greatly improved 2008 <a href="http://www.agdinteractive.com/games/qfg2/homepage/homepage.html" target="_blank">remake</a> 
+			a greatly improved 2008 <a href="http://www.agdinteractive.com/games/qfg2/homepage/homepage.html" class="day" target="_blank">remake</a> 
 			of <cite>Quest for Glory II: Trial by Fire</cite>.
 			</p>
 			<p>
-			A new "role-playing adventure game" entitled <cite><a href="http://hero-u.com/" target="_blank">Hero-U: Rogue to Redemption</a></cite> 
+			A new "role-playing adventure game" entitled <cite><a href="http://hero-u.com/" class="day" target="_blank">Hero-U: Rogue to Redemption</a></cite> 
 			has been developed by Sierra designers Corey and Lori Cole,
 			who were responsible for the <cite>Quest for Glory</cite> series.
-			The title has received overwhelmingly positive reviews from both <a href="https://store.steampowered.com/app/375440/HeroU_Rogue_to_Redemption/#app_reviews_hash">players</a> 
-			and <a href="https://adventuregamers.com/articles/view/35569" target="_blank">critics</a>. The game is intended to be the first 
-			of <a href="https://advgamer.blogspot.com/2018/07/interview-with-corey-cole.html" target="_blank">five similar titles</a>,
-			and a more casual game entitled <cite><a href="https://summerdazegame.com/" target="_blank">Summer Daze at Hero-U</a></cite> 
+			The title has received overwhelmingly positive reviews from both <a href="https://store.steampowered.com/app/375440/HeroU_Rogue_to_Redemption/#app_reviews_hash" class="day" target="_blank">players</a> 
+			and <a href="https://adventuregamers.com/articles/view/35569" class="day" target="_blank">critics</a>. The game is intended to be the first 
+			of <a href="https://advgamer.blogspot.com/2018/07/interview-with-corey-cole.html" class="day" target="_blank">five similar titles</a>,
+			and a more casual game entitled <cite><a href="https://summerdazegame.com/" class="day" target="_blank">Summer Daze at Hero-U</a></cite> 
 			is scheduled for release on June 22nd of this year.
 			</p>
 			<p>
 			A well-received 2013 game based on the series, 
-			entitled <cite><a href="http://store.steampowered.com/app/283880" target="_blank">Heroine's Quest</a></cite> is free to download.
+			entitled <cite><a href="http://store.steampowered.com/app/283880" class="day" target="_blank">Heroine's Quest</a></cite> is free to download.
 			The story, based on Norse mythology, takes place in a region cursed by a frost giant to be in endless winter.
 			The heroine must thwart the giant's attempts to bring about the end of the world and restore the normal change of seasons.
 			</p>
 			<p>
 			Many more downloads including screenshots can be found at a fan page 
-			called <a href="http://www.questformoreglory.com/index3.html" target="_blank">Quest for More Glory</a>,
+			called <a href="http://www.questformoreglory.com/index3.html" class="day" target="_blank">Quest for More Glory</a>,
 			while help for various problems, including the game's manual, 
-			is available at <a href="http://www.sierrahelp.com/Games/QuestForGlory/QfG1VGAHelp.html" target="_blank">Sierrahelp.com</a>.
+			is available at <a href="http://www.sierrahelp.com/Games/QuestForGlory/QfG1VGAHelp.html" class="day" target="_blank">Sierrahelp.com</a>.
 			Sierragamers.com supplies the 
-			<a href="https://www.sierragamers.com/wp-content/uploads/2019/12/Quest_for_Glory_1_Hint_Book.pdf" target="_blank">hint book</a>. 
+			<a href="https://www.sierragamers.com/wp-content/uploads/2019/12/Quest_for_Glory_1_Hint_Book.pdf" class="day" target="_blank">hint book</a>. 
 			</p>
 			<p>
 			A fan has created a modification to the classic first-person shooter game Hexen in which the player 
 			can move through much of the world of <cite>Quest for Glory IV</cite>.
-			Demo videos of this mod, known as <cite><a href="https://www.youtube.com/watch?v=d7HBenoe_Lc" target="_blank">Quest for Glory IV 3D</a></cite>, 
-			can be found on YouTube. His website, <a href="http://blakessanctum.x10.mx/Games/QFGSeries/index.html">Blake's Sanctum</a>, 
+			Demo videos of this mod, known as <cite><a href="https://www.youtube.com/watch?v=d7HBenoe_Lc" class="day" target="_blank">Quest for Glory IV 3D</a></cite>, 
+			can be found on YouTube. His website, <a href="http://blakessanctum.x10.mx/Games/QFGSeries/index.html" class="day">Blake's Sanctum</a>, 
 			contains extensive <cite><abbr class="day" title="Quest for Glory">QfG</abbr></cite>-related resources.
 			</p>
-			<div id="images" class="smaller-note"><a href="#container">Back to top &uarr;</a>
+			<div id="images" class="smaller-note"><a href="#container" class="day">Back to top &uarr;</a>
 			</div>
 			</section>
 			<section>
@@ -242,7 +242,7 @@
 				<span class="sr-only">Next</span>
 			    </a>
 			</div>
-			<div id="icons" class="smaller-note"><a href="#container">Back to top &uarr;</a></div>
+			<div id="icons" class="smaller-note"><a href="#container" class="day">Back to top &uarr;</a></div>
 			</section>
 			<section>
 			<h3>Icons</h3>
@@ -254,7 +254,7 @@
 			in which the player cannot intervene.
 			They appear different depending on whether it is day or night in the game, so they are presented in pairs below.
 			An attempt has already been made by others to implement	some of these as 
-			<a href="http://www.questformoreglory.com/downloads/qfg-cursorsT.html" target="_blank">extensions</a> to an operating system.
+			<a href="http://www.questformoreglory.com/downloads/qfg-cursorsT.html" class="day" target="_blank">extensions</a> to an operating system.
 			</p>
 			<img src="QfG_icons/qfg1-eye-icon.png" class="icon" id="eye-icon-daytime" alt="Quest for Glory I: So You Want to Be A Hero icon">
 			<img src="QfG_icons/qfg1-eye-icon-night.png" class="icon" id="eye-icon-nighttime" alt="Quest for Glory I: So You Want to Be A Hero icon">
@@ -274,7 +274,7 @@
 			<img src="QfG_icons/qfg1-question-mark-night.png" class="icon" id="question-icon-nighttime" alt="Quest for Glory I: So You Want to Be A Hero icon">
 			<img src="QfG_icons/qfg1-dragon-icon.png" class="icon" id="dragon-icon-daytime" alt="Quest for Glory I: So You Want to Be A Hero dragon waiting icon">
 			<img src="QfG_icons/qfg1-dragon-icon-night.png" class="icon" id="dragon-icon-nighttime" alt="Quest for Glory I: So You Want to Be A Hero dragon waiting icon">
-			<div id="music" class="smaller-note"><a href="#container">Back to top &uarr;</a></div>
+			<div id="music" class="smaller-note"><a href="#container" class="day">Back to top &uarr;</a></div>
 			</section>
 			</article>
 			<footer>
@@ -283,7 +283,7 @@
 			<br /> 
 			<br />
 			<br />
-			<a href="mailto:brendanfh@protonmail.com" id="contact">Contact me</a> | <a href="https://bdferr.github.io">Homepage</a>	 
+			<a href="mailto:brendanfh@protonmail.com" id="contact">Contact me</a> | <a href="https://bdferr.github.io" class="day">Homepage</a>	 
 			<br />
 			<br />
 		    <span id="day-mode">Day mode</span><span id="night-mode">Night mode</span></div>

--- a/quest-for-glory1.html
+++ b/quest-for-glory1.html
@@ -233,11 +233,11 @@
 				</div>
 			</div>
 			<!-- Carousel next and previous buttons -->
-				<a class="left carousel-control" href="#qfgCarousel" role="button" data-slide="prev">
+				<a class="left carousel-control carousel-control-day" href="#qfgCarousel" role="button" data-slide="prev">
 				<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 				<span class="sr-only">Previous</span>
 			    </a>
-			    <a class="right carousel-control" href="#qfgCarousel" role="button" data-slide="next">
+			    <a class="right carousel-control carousel-control-day" href="#qfgCarousel" role="button" data-slide="next">
 				<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 				<span class="sr-only">Next</span>
 			    </a>


### PR DESCRIPTION
Add daytime CSS class to links in QfG1 HTML so that it is applied without toggling day/night mode. Do the same with carousel controls.