### PR TITLE
Change QfG book page link hover color

### DIFF
--- a/qfg_book_stylesheet.css
+++ b/qfg_book_stylesheet.css
@@ -12,7 +12,7 @@ a:visted {
 	color: white;
 }
 a:hover {
-	color: blue;
+	color: cyan;
 	cursor: url("QfG_icons/QG1Sword.png"), default !important;
 }
 .button:hover {


### PR DESCRIPTION
On QfG book page, change color of links when mousing over them from blue to cyan for better readability.