### PR TITLE
Set cursor to QfG1 sword icon over form label

### DIFF
--- a/qfg_book_stylesheet.css
+++ b/qfg_book_stylesheet.css
@@ -81,6 +81,10 @@ h1 {
 h2 {
 	line-height: 100%;
 }
+label
+{
+	cursor: url("QfG_icons/QG1Sword.png"), default;
+}
 .red {
 	color: red;
 	font-family: gloryquest, "Pixelar Regular W01 Regular";


### PR DESCRIPTION
Set cursor to the same sword icon used elsewhere on the page for the label element in the form.