### PR TITLE
QfG3 page: Remove blank id attributes

### DIFF
--- a/quest-for-glory3.html
+++ b/quest-for-glory3.html
@@ -237,34 +237,34 @@
 			<!-- Carousel images -->
 			<div class="carousel-inner" role="listbox">
 				<div class="item active">
-				<img src="qfg3-heart-of-world-trunk2.webp" id="" alt="Quest for Glory III: Wages of War screenshot Heart of World" />
+				<img src="qfg3-heart-of-world-trunk2.webp" alt="Quest for Glory III: Wages of War screenshot Heart of World" />
 				</div>
 				<div class="item">
-				<img src="qfg3-bedroom1.webp" id="" alt="Quest for Glory III: Wages of War screenshot bedroom at inn" />
+				<img src="qfg3-bedroom1.webp" alt="Quest for Glory III: Wages of War screenshot bedroom at inn" />
 				</div>
 				<div class="item">
-				<img src="qfg3-time-and-date2.png" id="" alt="Quest for Glory III: Wages of War screenshot savannah overview with time of night" />
+				<img src="qfg3-time-and-date2.png" alt="Quest for Glory III: Wages of War screenshot savannah overview with time of night" />
 				</div>
 				<div class="item">
-				<img src="qfg3-tarna-gates.webp" id="" alt="Quest for Glory III: Wages of War screenshot gates of Tarna" />
+				<img src="qfg3-tarna-gates.webp" alt="Quest for Glory III: Wages of War screenshot gates of Tarna" />
 				</div>
 				<div class="item">
-				<img src="qfg3-manu-cowardly.png" id="" alt="Quest for Glory III: Wages of War screenshot monkey guide in jungle" />
+				<img src="qfg3-manu-cowardly.png" alt="Quest for Glory III: Wages of War screenshot monkey guide in jungle" />
 				</div>
 				<div class="item">
-				<img src="qfg3-demon-1.png" id="" alt="Quest for Glory III: Wages of War screenshot demon battle" />
+				<img src="qfg3-demon-1.png" alt="Quest for Glory III: Wages of War screenshot demon battle" />
 				</div>
 				<div class="item">
-				<img src="qfg3-settings.webp" id="" alt="Quest for Glory III: Wages of War screenshot settings menu" />
+				<img src="qfg3-settings.webp" alt="Quest for Glory III: Wages of War screenshot settings menu" />
 				</div>
 				<div class="item">
-				<img src="qfg3-leopardmen-village-night.webp" id="" alt="Quest for Glory III: Wages of War screenshot leopardmen village at night" />
+				<img src="qfg3-leopardmen-village-night.webp" alt="Quest for Glory III: Wages of War screenshot leopardmen village at night" />
 				</div>
 				<div class="item">
-				<img src="qfg3-pool-of-peace1.webp" id="" alt="Quest for Glory III: Wages of War screenshot Pool of Peace" />
+				<img src="qfg3-pool-of-peace1.webp" alt="Quest for Glory III: Wages of War screenshot Pool of Peace" />
 				</div>
 				<div class="item">
-				<img src="qfg3-main-menu3.webp" id="" alt="Quest for Glory III: Wages of War screenshot main menu" />
+				<img src="qfg3-main-menu3.webp" alt="Quest for Glory III: Wages of War screenshot main menu" />
 				</div>
 			</div>
 			<!-- Carousel next and previous buttons -->


### PR DESCRIPTION
Remove the blank "id" attributes from the images in the QfG3 carousel.