### PR TITLE
simplify time and date

### DIFF
--- a/quest-for-glory3.html
+++ b/quest-for-glory3.html
@@ -9,7 +9,7 @@
 	<meta name="description" content="Fanpage for the Sierra role-playing adventure game Quest for Glory III,
 	demonstrating Bootstrap and jQuery. Applies UI elements of game to website."/>
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2022-10-01" />
+	<meta name="dcterms.modified" content="2024-05-06" />
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
 	<!--[if lt IE 9]>
@@ -112,7 +112,7 @@
 			months = ["January", "February", "March", "April", "May", "June", "July",
 			"August", "September", "October", "November", "December"];
 			month = d.getMonth();
-			now = addZeroes(d.getHours()) + ":" + addZeroes(d.getMinutes()) + ":" + addZeroes(d.getSeconds()) + " on " 
+			now = addZeroes(d.getHours()) + ":" + addZeroes(d.getMinutes()) + " on " 
 			+ months[month] + " " + d.getDate() + ", " + d.getFullYear() + ".";
 			$("#now").html("It's " + now);
 			time = $("#time-and-date-toggle").attr("class");

--- a/quest-for-glory3.html
+++ b/quest-for-glory3.html
@@ -320,7 +320,7 @@
 			</article>
 			<footer class="day">
 			<br />
-			<div class="smaller-note">&copy; 2021 Brendan 
+			<div class="smaller-note">&copy; 2024 Brendan 
 			<br /> Ferreri-Hanberry 
 			<br /> 
             <br />

--- a/quest-for-glory4-de.html
+++ b/quest-for-glory4-de.html
@@ -286,7 +286,7 @@
 			</section>
 			</article>
 			<footer>
-			<div class="smaller-note">&copy; 2023 Brendan Ferreri-Hanberry <br /> 
+			<div class="smaller-note">&copy; 2024 Brendan Ferreri-Hanberry <br /> 
 			<br />
 			<a href="mailto:brendanfh@protonmail.com" id="contact">Kontakt</a>&nbsp; | &nbsp;<a href="https://bdferr.github.io"><abbr title="zur Startseite">Home</abbr></a>&nbsp; 
 			|&nbsp;<span id="time-and-date-toggle">Tag u. Zeit</span>

--- a/quest-for-glory4-de.html
+++ b/quest-for-glory4-de.html
@@ -9,7 +9,7 @@
 	<meta name="description" content="Diese Fanseite für das Rollen-Abenteuerspiel Quest for Glory IV von Sierra
 	führt Bootstrap und jQuery vor und versucht, die Benutzeroberfläche des Spiels auf eine Website anzuwenden."/>
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2023-05-24" />
+	<meta name="dcterms.modified" content="2024-05-06" />
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
 	<link rel="alternate" href="quest-for-glory.html" hreflang="en">
@@ -57,7 +57,7 @@
 			months = ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli",
 			"August", "September", "Oktober", "November", "Dezember"];
 			month = d.getMonth();
-			now = addZeroes(d.getHours()) + ":" + addZeroes(d.getMinutes()) + ":" + addZeroes(d.getSeconds()) + " am " 
+			now = addZeroes(d.getHours()) + ":" + addZeroes(d.getMinutes()) + " am " 
 			+ d.getDate() + "." +  " " + months[month] + " " + d.getFullYear() + ".";
 			$("#now").html("Es ist " + now);
 			$("#time-and-date").toggle();

--- a/quest-for-glory4-it.html
+++ b/quest-for-glory4-it.html
@@ -9,7 +9,7 @@
 	<meta name="description" content="Fanpage for the Sierra role-playing adventure game Quest for Glory IV,
 	demonstrating Bootstrap and jQuery. Applies UI elements of game to website."/>
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2023-05-24" />
+	<meta name="dcterms.modified" content="2024-05-06" />
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
 	<link rel="alternate" href="quest-for-glory.html" hreflang="en">
@@ -57,7 +57,7 @@
 			months = ["gennaio", "febbraio", "marzo", "aprile", "maggio", "giugno", "luglio",
 			"agosto", "settembre", "ottobre", "novembre", "dicembre"];
 			month = d.getMonth();
-			now = addZeroes(d.getHours()) + ":" + addZeroes(d.getMinutes()) + ":" + addZeroes(d.getSeconds()) + " il " 
+			now = addZeroes(d.getHours()) + ":" + addZeroes(d.getMinutes()) + " il " 
 			+ d.getDate() +  " " + months[month] + " " + d.getFullYear() + ".";
 			hours = [0, 1, 12, 13];
 			hour = d.getHours();

--- a/quest-for-glory4-it.html
+++ b/quest-for-glory4-it.html
@@ -274,7 +274,7 @@
 			</section>
 			</article>
 			<footer>
-			<div class="smaller-note">&copy; 2023 Brendan Ferreri-Hanberry <br /> 
+			<div class="smaller-note">&copy; 2024 Brendan Ferreri-Hanberry <br /> 
 			<br />
 			<a href="mailto:brendanfh@protonmail.com" id="contact">Contattare</a>&nbsp;|&nbsp;<a href="https://bdferr.github.io"><abbr title="pagina iniziale">Home</abbr></a>&nbsp; 
 			|&nbsp;<span id="time-and-date-toggle">Data e ora</span>

--- a/quest-for-glory4.html
+++ b/quest-for-glory4.html
@@ -9,7 +9,7 @@
 	<meta name="description" content="Fanpage for the Sierra role-playing adventure game Quest for Glory IV,
 	demonstrating Bootstrap and jQuery. Applies UI elements of game to website."/>
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2023-05-24" />
+	<meta name="dcterms.modified" content="2024-05-06" />
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
 	<link rel="alternate" href="quest-for-glory.html" hreflang="en">
@@ -58,7 +58,7 @@
 			months = ["January", "February", "March", "April", "May", "June", "July",
 			"August", "September", "October", "November", "December"];
 			month = d.getMonth();
-			now = addZeroes(d.getHours()) + ":" + addZeroes(d.getMinutes()) + ":" + addZeroes(d.getSeconds()) + " on " 
+			now = addZeroes(d.getHours()) + ":" + addZeroes(d.getMinutes()) + " on " 
 			+ months[month] + " " + d.getDate() + ", " + d.getFullYear() + ".";
 			$("#now").html("It's " + now);
 			$("#time-and-date").toggle();

--- a/quest-for-glory4.html
+++ b/quest-for-glory4.html
@@ -282,7 +282,7 @@
 			</section>
 			</article>
 			<footer>
-			<div class="smaller-note">&copy; 2023 Brendan Ferreri-Hanberry <br /> 
+			<div class="smaller-note">&copy; 2024 Brendan Ferreri-Hanberry <br /> 
 			<br />
 			<a href="mailto:brendanfh@protonmail.com" id="contact">Contact</a>&nbsp; | &nbsp;<a href="https://bdferr.github.io">Home</a>&nbsp; |&nbsp;<span id="time-and-date-toggle">Time & Date</span>
 			<br />


### PR DESCRIPTION
Remove seconds from time and date displays on QfG3 and QfG4 pages. Also update copyright dates in footers.